### PR TITLE
fix null pointer bugs

### DIFF
--- a/code/app/src/main/java/com/example/projecteventlotteryapp/Activities/EntrantSettingsActivity.java
+++ b/code/app/src/main/java/com/example/projecteventlotteryapp/Activities/EntrantSettingsActivity.java
@@ -93,10 +93,26 @@ public class EntrantSettingsActivity extends AppCompatActivity {
         // Load the current notification status from Firestore
         db.loadUserProfile(deviceID, globalUser.getRole()).addOnSuccessListener(documentSnapshot -> {
             if (documentSnapshot.exists()) {
-                boolean notificationEnabled = documentSnapshot.getBoolean("notificationEnabled");
-                // default to true if the field doesn't exist yet
-                swtchNotification.setChecked(notificationEnabled);
+                Boolean notificationEnabled = documentSnapshot.getBoolean("notificationEnabled");
+
+                // If the field doesn't exist yet
+                if (notificationEnabled == null) {
+                    Map<String, Object> initialUpdate = new HashMap<>();
+                    initialUpdate.put("notificationEnabled", true); // set the field to true by default
+                    db.updateUserProfile(deviceID, initialUpdate, globalUser.getRole()).addOnSuccessListener(unused -> {
+                        // If default setting was successfully made, set the switch to true
+                        swtchNotification.setChecked(true);
+                    }).addOnFailureListener(e -> {
+                        Log.e("PROFILE", "Failed to update notification status", e);
+                        Toast.makeText(this, "Failed to update notification status", Toast.LENGTH_SHORT).show();
+                        // Revert the switch visual state if the database update failed
+                        swtchNotification.setChecked(false);
+                    });
+                } else {
+                    swtchNotification.setChecked(notificationEnabled);
+                }
             }
+
         });
 
         // Save the status immediately when the user toggles the switch
@@ -120,6 +136,9 @@ public class EntrantSettingsActivity extends AppCompatActivity {
         });
 
     }
+
+
+
 
     /**
      * Loads the users profile from firestore.

--- a/code/app/src/main/java/com/example/projecteventlotteryapp/Activities/RegistrationActivity.java
+++ b/code/app/src/main/java/com/example/projecteventlotteryapp/Activities/RegistrationActivity.java
@@ -166,6 +166,7 @@ public class RegistrationActivity extends AppCompatActivity {
         userData.put("name", name);
         userData.put("email", email);
         userData.put("phone", phone);
+        userData.put("notificationEnabled", true);
 
         // Add data to Firestore
         userRef.set(userData)
@@ -180,11 +181,14 @@ public class RegistrationActivity extends AppCompatActivity {
                     MyApp app = (MyApp) getApplication();
                     app.setCurrentUser(user);
 
-                    // Temporary handling of page routing, will add more cases for organizer and entrant for now
                     Intent intent;
                     if (role == Role.ADMIN) {
                         intent = new Intent(RegistrationActivity.this, AdminHomeActivity.class);
-                    } else {
+                    }
+                    else if (role == Role.ORGANIZER) {
+                        intent = new Intent(RegistrationActivity.this, EventsListActivity.class);
+                    }
+                    else {
                         intent = new Intent(RegistrationActivity.this, EventsListActivity.class);
                     }
                     startActivity(intent);


### PR DESCRIPTION
fixed null pointer issue by adding notificationsEnabled field to new account creation, and defaulting the field to "true" on users who access the settings page and don't have the field already initialized (essentailly only old accounts made before today)