### PR TITLE
changed all /'draw date/' to /'start date/' in ui

### DIFF
--- a/code/app/src/main/java/com/example/projecteventlotteryapp/AdminEventArrayAdapter.java
+++ b/code/app/src/main/java/com/example/projecteventlotteryapp/AdminEventArrayAdapter.java
@@ -54,9 +54,9 @@ public class AdminEventArrayAdapter extends ArrayAdapter<Event> {
         if (event.getDrawDate() != null) {
             DateTimeFormatter datePattern = DateTimeFormatter.ofPattern("MMMM d, yyyy 'at' h:mm a");
             String formattedDate = event.getDrawDate().format(datePattern);
-            drawDateTextView.setText("Drawn on " + formattedDate);
+            drawDateTextView.setText("Starts on " + formattedDate);
         } else {
-            drawDateTextView.setText("Draw date TBD");
+            drawDateTextView.setText("Start date TBD");
         }
         
         attendeesTextView.setText("Attendees: " + event.getAttendeesLimit());

--- a/code/app/src/main/res/layout/activity_edit_event.xml
+++ b/code/app/src/main/res/layout/activity_edit_event.xml
@@ -119,7 +119,7 @@
                 style="@style/HeaderRoundedEditTextStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Draw Date"
+                android:text="Start Date"
                 app:layout_constraintBottom_toTopOf="@+id/et_event_edit_draw_date"
                 app:layout_constraintStart_toStartOf="@+id/et_event_edit_draw_date" />
 

--- a/code/app/src/main/res/layout/activity_event_details.xml
+++ b/code/app/src/main/res/layout/activity_event_details.xml
@@ -118,7 +118,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginTop="10dp"
-            android:text="Draw Date"
+            android:text="Start Date"
             android:textSize="16sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/cl_poster_area" />

--- a/code/app/src/main/res/layout/fragment_create_event.xml
+++ b/code/app/src/main/res/layout/fragment_create_event.xml
@@ -97,7 +97,7 @@
         style="@style/HeaderRoundedEditTextStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Draw Date"
+        android:text="Start Date"
         app:layout_constraintBottom_toTopOf="@+id/et_event_edit_draw_date"
         app:layout_constraintEnd_toEndOf="@+id/et_event_edit_draw_date"
         app:layout_constraintHorizontal_bias="0.05"

--- a/code/app/src/main/res/layout/fragment_filter_events.xml
+++ b/code/app/src/main/res/layout/fragment_filter_events.xml
@@ -188,7 +188,7 @@
         android:id="@+id/tv_filter_draw_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Draw Date"
+        android:text="Start Date"
         android:layout_marginTop="17dp"
         app:layout_constraintHorizontal_bias="0.05"
         app:layout_constraintTop_toBottomOf="@id/et_filter_registration_start"


### PR DESCRIPTION
Updated all instances of "Draw Date" to "Start Date" as draw date is no longer something we want to keep track of. DB entries and java code will still reference drawDate, it just represents the start date now